### PR TITLE
Retrieve type value with get method

### DIFF
--- a/hackchat.py
+++ b/hackchat.py
@@ -75,7 +75,7 @@ class HackChat:
             elif result["cmd"] == "onlineSet":
                 for nick in result["nicks"]:
                     self.online_users.append(nick)
-            elif result["cmd"]=="info" and result["type"]=="whisper":
+            elif result["cmd"]=="info" and result.get("type")=="whisper":
                 for handler in list(self.on_whisper):
                     handler(self,result["text"],result["from"],result)
 


### PR DESCRIPTION
`info` message does not have to contain `type` name:

```json
{"cmd": "info", "text": "New beta available at: https://beta.hack.chat/ or https://beta.hack.chat/?asdasd", "channel": "asdasd", "time": 1606659611662}
```

therefore it is safer to retrieve its value with `get` method to avoid unnecessary Exception.